### PR TITLE
Support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Makefile
+doc/man/Makefile
+src/Makefile
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM debian:stretch-slim as build
+
+# Install our build dependencies
+RUN apt-get update \
+  && apt-get install -y \
+    build-essential \
+  	pkg-config \
+  	libc6-dev \
+  	m4 \
+  	g++-multilib \
+    autoconf \
+  	libtool \
+  	ncurses-dev \
+  	unzip \
+  	git \
+  	python \
+    zlib1g-dev \
+  	wget \
+  	bsdmainutils \
+  	automake \
+  	p7zip-full \
+  	pwgen \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/src/
+COPY . /usr/local/src/
+
+RUN ./zcutil/build.sh -j$(nproc)
+RUN ./zcutil/fetch-params.sh
+
+FROM debian:stretch-slim
+
+# Add our user and group first to ensure consistency
+RUN groupadd -r bitcoinz && useradd -r -d /bitcoinz -g bitcoinz bitcoinz
+
+# Install our run dependencies
+RUN apt-get update \
+  && apt-get install -y \
+    libc6-dev \
+    g++-multilib \
+  && rm -rf /var/lib/apt/lists/*
+
+# Setup application directory
+RUN mkdir -p /bitcoinz/data
+
+# Copy binaries from build container
+COPY --from=build /usr/local/src/src/zcashd /usr/local/bin
+COPY --from=build /usr/local/src/src/zcash-cli /usr/local/bin
+COPY --from=build /usr/local/src/src/zcash-gtest /usr/local/bin
+COPY --from=build /usr/local/src/src/zcash-tx /usr/local/bin
+COPY contrib/docker/cli /usr/local/bin
+
+RUN chmod +x /usr/local/bin/cli
+
+# Copy zcash params
+COPY --from=build /root/.zcash-params /bitcoinz/.zcash-params
+
+RUN chown -R bitcoinz: /bitcoinz
+USER bitcoinz
+WORKDIR /bitcoinz
+CMD ["zcashd", "--datadir=/bitcoinz/data"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,56 @@ Install
 ./src/zcashd
 ```
 
+### Docker
+
+Build
+```
+$ docker build -t btcz/bitcoinz .
+```
+
+Create a data directory on your local drive and create a bitcoinz.conf config file
+```
+$ mkdir -p /ops/volumes/bitcoinz/data
+$ touch /ops/volumes/bitcoinz/data/bitcoinz.conf
+$ chown -R 999:999 /ops/volumes/bitcoinz/data
+```
+
+Create bitcoinz.conf config file and run the application
+```
+$ docker run -d --name bitcoinz-node \
+  -v bitcoinz.conf:/bitcoinz/data/bitcoinz.conf \
+  -p 1989:1989 -p 127.0.0.1:1979:1979 \
+  btcz/bitcoinz
+```
+
+Verify bitcoinz-node is running
+```
+$ docker ps
+CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS                                              NAMES
+31868a91456d        btcz/bitcoinz          "zcashd --datadir=..."   2 hours ago         Up 2 hours          127.0.0.1:1979->1979/tcp, 0.0.0.0:1989->1989/tcp   bitcoinz-node
+```
+
+Follow the logs
+```
+docker logs -f bitcoinz-node
+```
+
+The cli command is a wrapper to zcash-cli that works with an already running Docker container
+```
+docker exec -it bitcoinz-node cli help
+```
+
+## Using a Dockerfile
+If you'd like to have a production btc/bitcoinz image with a pre-baked configuration
+file, use of a Dockerfile is recommended:
+
+```
+FROM btcz/bitcoinz
+COPY bitcoinz.conf /bitcoinz/data/bitcoinz.conf
+```
+
+Then, build with `docker build -t my-bitcoinz .` and run.
+
 ### Windows
 Windows build is maintained in [bitcoinz-win project](https://github.com/bitcoinz-pod/bitcoinz-win).
 

--- a/contrib/docker/cli
+++ b/contrib/docker/cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec zcash-cli --datadir=/bitcoinz/data "${@}"

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -101,8 +101,6 @@ public:
         vSeeds.clear();
         // use name as: echo -n hostname | sha256sum
         vSeeds.push_back(CDNSSeedData("4437c91da6e4c4edca56b57bd52c2e11a3fd7d8b04bd9dec9584fb5220f54b05.BTCZ", "btzseed.blockhub.info"));
-        vSeeds.push_back(CDNSSeedData("8f5854b5a55e7e440f86061528d138245e56c53ed2a494b0376a7d4919d51d21.BTCZ", "seed.bitcoinz.ph"));
-        vSeeds.push_back(CDNSSeedData("7e2071b6fc04a4b47d4973958d931d41479ffe069dc4c611f4a9d8ce8be737a9.BTCZ", "zparty.pl"));
         vSeeds.push_back(CDNSSeedData("6587c9bfccb608dddf1dbba7e2ec8fc91ebe70138e175e2949f3588934687b9b.BTCZ", "dnsseed.kemperink.org"));
         vSeeds.push_back(CDNSSeedData("a094ea4307abc8b674662175d8e0627c4a30e4916b98ca4b160c2de6e321767c.BTCZ", "seeder.nomadteam.net"));
         vSeeds.push_back(CDNSSeedData("487658a406d62f020c5656d50923f094a688b92d6c85b3ccd8769b60b2c6449f.BTCZ", "btcz.webrats.com"));


### PR DESCRIPTION
This commit adds minimal support for docker. The goal is to have an
automated build in Docker hub that is automatically updated when an
change is made to the bitcoinz code base. Developers can then use
this to extend and write apps around the bitcoinz app using docker.