### PR TITLE
Added volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ RUN chmod +x /usr/local/bin/cli
 # Copy zcash params
 COPY --from=build /root/.zcash-params /bitcoinz/.zcash-params
 
+# Add volume to use as persistent storage
+VOLUME ["/bitcoinz/data"]
 RUN chown -R bitcoinz: /bitcoinz
 USER bitcoinz
 WORKDIR /bitcoinz


### PR DESCRIPTION
Add volume to use as persistent storage and do not download blockchanin ever rebuild and to store a wallet on the host.

You can use 
```
docker build -t -v host_storage:/bitcoinz/data my-bitcoinz . 
```