### PR TITLE
Add support for Snowgem's ModernWallet

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -30,6 +30,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setgenerate", 0 },
     { "setgenerate", 1 },
     { "generate", 0 },
+    { "getalldata", 0 },
     { "getnetworkhashps", 0 },
     { "getnetworkhashps", 1 },
     { "sendtoaddress", 1 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -259,6 +259,7 @@ static const CRPCCommand vRPCCommands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
     /* Overall control/query calls */
+    { "control",            "getalldata",             &getalldata,             true  },
     { "control",            "getinfo",                &getinfo,                true  }, /* uses wallet if enabled */
     { "control",            "help",                   &help,                   true  },
     { "control",            "stop",                   &stop,                   true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -234,6 +234,7 @@ extern UniValue walletpassphrasechange(const UniValue& params, bool fHelp);
 extern UniValue walletlock(const UniValue& params, bool fHelp);
 extern UniValue encryptwallet(const UniValue& params, bool fHelp);
 extern UniValue validateaddress(const UniValue& params, bool fHelp);
+extern UniValue getalldata(const UniValue& params, bool fHelp);
 extern UniValue getinfo(const UniValue& params, bool fHelp);
 extern UniValue getwalletinfo(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2989,7 +2989,7 @@ UniValue z_listaddresses(const UniValue& params, bool fHelp)
     return ret;
 }
 
-CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ignoreUnspendable=true) {
+CAmount getBalanceTaddr(std::string transparentAddress, int minDepth, bool ignoreUnspendable) {
     set<CBitcoinAddress> setAddress;
     vector<COutput> vecOutputs;
     CAmount balance = 0;
@@ -3032,7 +3032,7 @@ CAmount getBalanceTaddr(std::string transparentAddress, int minDepth=1, bool ign
     return balance;
 }
 
-CAmount getBalanceZaddr(std::string address, int minDepth = 1, bool ignoreUnspendable=true) {
+CAmount getBalanceZaddr(std::string address, int minDepth, bool ignoreUnspendable) {
     CAmount balance = 0;
     std::vector<CNotePlaintextEntry> entries;
     LOCK2(cs_main, pwalletMain->cs_wallet);


### PR DESCRIPTION
Summary:
In order for Snowgem to be able to add BitcoinZ to their ModernWallet,
they need us to add a getalldata command that provides it with all the
information it needs quickly. This command enables this.

Test Plan:
I've compiled this in a node node and verified that I was able to see
the new command in help, as well as execute it to get the expected
response.  A sample of the response data looks as follows:
```json
{
  "connectionCount": 3,
  "besttime": 1513645152,
  "bestblockhash": "0000000339ab2556d7a8af4c83b9c4d6771e6efc4b1c284b2b6705f61339736b",
  "transparentbalance": "0.00",
  "privatebalance": "0.00",
  "lockedbalance": "0.00",
  "totalbalance": "0.00",
  "unconfirmedbalance": "0.00",
  "immaturebalance": "0.00",
  "addressbalance": [
    {
      "": 0.00000000
    }
  ],
  "listtransactions": [
    {
      "account": "",
      "address": "",
      "category": "",
      "amount": "0",
      "vout": "1",
      "confirmations": "0",
      "generated": "true",
      "blockhash": "0000000000000000000000000000000000000000000000000000000000000000",
      "blockindex": "0",
      "blocktime": "0",
      "txid": "0000000000000000000000000000000000000000000000000000000000000000",
      "time": "0",
      "timereceived": "0"
    }
  ]
}
```