### PR TITLE
take next block subsidy

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -896,7 +896,7 @@ UniValue getblocksubsidy(const UniValue& params, bool fHelp)
     if (nHeight < 0)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 
-    CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
+    CAmount nReward = GetBlockSubsidy(nHeight + 1, Params().GetConsensus());
     CAmount nFoundersReward = 0;
     if ((nHeight > 0) && (nHeight <= Params().GetConsensus().GetLastFoundersRewardBlockHeight())) {
         nFoundersReward = nReward/5;


### PR DESCRIPTION
get next block subsidy since you compute the reward for the next block. 

At halving this would cause the submit block process to fail the reward validation.