### PR TITLE
Fixed minor issue with tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ doc/man/Makefile
 src/Makefile
 Dockerfile
 qa/Dockerfile.test
+qa/docker-run-tests.sh

--- a/qa/bitcoinz/full_test_suite.py
+++ b/qa/bitcoinz/full_test_suite.py
@@ -67,7 +67,7 @@ def check_security_hardening():
     ret &= test_rpath_runpath('src/zcash-gtest')
     ret &= test_rpath_runpath('src/bitcoinz-tx')
     ret &= test_rpath_runpath('src/test/test_bitcoin')
-    ret &= test_rpath_runpath('src/bitcoinz/GenerateParams')
+    ret &= test_rpath_runpath('src/zcash/GenerateParams')
 
     # NOTE: checksec.sh does not reliably determine whether FORTIFY_SOURCE
     # is enabled for the entire binary. See issue #915.
@@ -76,7 +76,7 @@ def check_security_hardening():
     ret &= test_fortify_source('src/zcash-gtest')
     ret &= test_fortify_source('src/bitcoinz-tx')
     ret &= test_fortify_source('src/test/test_bitcoin')
-    ret &= test_fortify_source('src/bitcoinz/GenerateParams')
+    ret &= test_fortify_source('src/zcash/GenerateParams')
 
     return ret
 


### PR DESCRIPTION
This commit fixes a minor issue with the test runner that was probably
introduced by an update. Basically, GenerateParams file should live in
the zcash directory not the bitcoinz directory.