### PR TITLE
Update equihash.h

### DIFF
--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -10,6 +10,7 @@
 #include "utilstrencodings.h"
 
 #include "sodium.h"
+#include <stdexcept>
 
 #include <cstring>
 #include <exception>


### PR DESCRIPTION
#include <stdexcept>
fixed-size integer types like "uint32_t" and "uint8_t"
